### PR TITLE
Prevent "From " needle from being inserted in between all chunks

### DIFF
--- a/src/mbox.js
+++ b/src/mbox.js
@@ -75,7 +75,8 @@ function MboxStream(input, opts) {
   this.on('finish', function() {
     if (chunks.length) {
       stream.number_of_messages++;
-      stream.emit('message', chunks.join(''));
+      // Add the needle back in when emitting
+      stream.emit('message', 'From ' + chunks.join(''));
     }
     this.emit('end', stream.number_of_messages);
   });
@@ -84,12 +85,12 @@ function MboxStream(input, opts) {
   this.searcher = new StreamSearch('\nFrom ');
   this.searcher.on('info', function(isMatch, chunk, start, end) {
     if (chunk) {
-      // Add needle.
-      chunks.push( 'From ' + chunk.toString(stream.encoding, start, end) );
+      chunks.push( chunk.toString(stream.encoding, start, end) );
     }
     if (isMatch && chunks.length) {
       stream.number_of_messages++;
-      stream.emit('message', chunks.join(''));
+      // Add the needle back in when emitting
+      stream.emit('message', 'From ' + chunks.join(''));
       chunks = [];
     }
   });


### PR DESCRIPTION
Previously, "From " was being inserted back into the data stream whenever `streamsearch` provided a new chunk of data. However, `streamsearch` will provide data chunks where there has been no match, and thus no removal of "From ". The result was that "From " was being erroneously inserted into longer data streams.

I noticed this dealing with larger data streams with base64 attachments that would result in corrupted files.