### PR TITLE
Support use of through2 as the source stream

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-mbox",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "mbox parser for Node",
   "scripts" : {
     "test" : "mocha -R spec --require should test/"

--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
   "name": "node-mbox",
   "version": "0.2.1",
   "description": "mbox parser for Node",
-  "scripts" : {
-    "test" : "mocha -R spec --require should test/"
+  "scripts": {
+    "test": "mocha -R spec --require should test/"
   },
   "author": {
     "name": "Robert Klep",
@@ -28,6 +28,7 @@
     "should": "^4.0.4"
   },
   "dependencies": {
+    "isstream": "^0.1.2",
     "streamsearch": "^0.1.2"
   }
 }

--- a/src/mbox.js
+++ b/src/mbox.js
@@ -4,6 +4,7 @@ var StreamSearch  = require('streamsearch');
 var util          = require('util');
 var fs            = require('fs');
 var Stream        = require('stream');
+var isStream      = require('isstream');
 
 util.inherits(StringReader, Readable);
 util.inherits(MboxStream, Transform);
@@ -43,7 +44,7 @@ function MboxStream(input, opts) {
         handle = new StringReader(input);
     }
     else
-    if (klass === 'ReadStream' || klass === 'DestroyableTransform')
+    if (isStream(input))
       handle = input;
     else
     if (klass === 'Object')

--- a/src/mbox.js
+++ b/src/mbox.js
@@ -43,7 +43,7 @@ function MboxStream(input, opts) {
         handle = new StringReader(input);
     }
     else
-    if (klass === 'ReadStream')
+    if (klass === 'ReadStream' || klass === 'DestroyableTransform')
       handle = input;
     else
     if (klass === 'Object')


### PR DESCRIPTION
Supports using a through2 stream as input.  I'm performing pretty intense processing on each mbox message and since the parser is continuously reading and spitting out messages I'm quickly running out of memory.  I'm using through2 to basically pause the reading of the file, then resume it later on once things are caught up.  This change was necessary to make the constructor recognize that the through2 stream was a stream.

Here's an example:
``` 
       var pausableSource = this.src.pipe(through2(function(chunk, enc, callback) {

          this.push(chunk);

          // Pause processing if we're too far ahead
          if ((self.messageCount - self.processed) > MAX_MBOX_MESSAGES_IN_FLIGHT) {
            if (!self.processingPaused) {
              self.processingPaused = true;
              self.src.pause();
              self.srcCallback = callback;
            }
          } else {
            callback();
          }

        }));

        let mbox = new Mbox(pausableSource, { /* options */ });

.... later on:
    if (this.processingPaused) {

      if ((this.messageCount - this.processed) < MAX_MBOX_MESSAGES_IN_FLIGHT) {
        this.processingPaused = false;
        this.srcCallback();
      }
    }


```
